### PR TITLE
Added fix for long post titles on posts list

### DIFF
--- a/assets/scss/_main.scss
+++ b/assets/scss/_main.scss
@@ -163,6 +163,8 @@ header ul li {
 
     .posts-title {
         float: right;
+        width: 80%;
+        text-align: right;
     }
 }
 


### PR DESCRIPTION
This commit contains a fix which allows for long post titles to display within the main posts list without dropping beneath the date of the post.