### PR TITLE
Replaced Twitter links with Mastodon links

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The default values in the following should be replaced:
 licenseType = "CC BY 4.0"
 licenseLink = "https://creativecommons.org/licenses/by/4.0"
 issuesLink = "https://github.com/stuartmccoll/hugo-theme-refresh/issues/new"
-twitterUsername = "itstuartmccoll"
+mastodonUsername = "@stuartmccoll@hachyderm.io"
 ```
 
 ## License

--- a/config.toml
+++ b/config.toml
@@ -16,11 +16,11 @@ title = "Site Title"
     # Link to create a new GitHub issue
     issuesLink = "https://github.com/stuartmccoll/hugo-theme-refresh/issues/new"
 
-    # Flag to toggle inclusion of Twitter link
-    includeTwitter = true
+    # Flag to toggle inclusion of Mastodon link
+    includeMastodon = true
 
-    # Twitter username
-    twitterUsername = "itstuartmccoll"
+    # Mastodon username
+    mastodonUsername = "@stuartmccoll@hachyderm.io"
 
     # Flag to toggle inclusion of Hugo version details
     includeHugoVersion = true

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,28 +1,14 @@
 <footer>
-    {{ if ne .Page.Title "About" }}
-    {{ if ne .Page.Title "Posts" }}
-    {{ if not .Page.IsHome }}
-    <section>
-        <h3>Share this content</h3>
-        <p>
-            <a
-                href="https://twitter.com/intent/tweet?url=https://stuartmccoll.github.io{{ .Page.RelPermalink }}&via=itstuartmccoll&text=I%27m%20reading">
-                Tweet this blog post
-            </a>
-        </p>
-    </section>
-    <hr />
-    {{ end }}
-    {{ end }}
-    {{ end}}
     <section>
         <h3>More</h3>
         <ul>
             {{ if .Site.Params.includeIssues }}
             <li>
                 <a
-                    href="https://twitter.com/intent/tweet?text=%40{{ .Site.Params.twitterUsername }}%20Hello%2C%20%3Cinsert%20message%20here%3E">
-                    Contact me on Twitter
+                    href="https://hachyderm.io/@stuartmccoll"
+                    rel="me"
+                >
+                    Contact me on Mastodon
                 </a>
             </li>
             {{ end }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -27,7 +27,6 @@
 {{- end }}
 {{- partial "favicons.html" }}
 {{- template "_internal/schema.html" . }}
-{{- template "_internal/twitter_cards.html" . }}
 {{- range .Params.categories }}
 <meta property="article:section" content="{{ . }}" />{{ end }}
 {{- if isset .Params "date" }}

--- a/theme.toml
+++ b/theme.toml
@@ -9,4 +9,4 @@ min_version = 0.1
 [author]
   name = "Stuart McColl"
   homepage = "https://stuartmccoll.co.uk"
-  twitter = "https://twitter.com/itstuartmccoll"
+  mastodon = "https://hachyderm.io/@stuartmccoll"


### PR DESCRIPTION
This commit replaces all Twitter links and configuration with corresponding Mastodon links and configuration.