### PR TITLE
Added PowerShell syntax highlighting CSS

### DIFF
--- a/assets/scss/_syntax_powershell.scss
+++ b/assets/scss/_syntax_powershell.scss
@@ -1,0 +1,87 @@
+/*
+* Chroma PowerShell Console Style v1.0
+* 
+* https://github.com/pauby/chroma-powershellconsole-css
+* 
+*/
+
+#pscode-highlight-error .hl {
+    background-color: #000000;
+    display: block;
+    width: 100%;
+}
+
+#pscode-highlight-error .hl span {
+    color: #ff0000;
+    background-color: #000000;
+}
+
+pre.chroma:has(> .language-powershell) { background-color: #012456; padding: 0.75rem; }
+
+/* Background */ .chroma > .language-powershell { color: #ffffff; background-color: #012456; }
+/* Error */ .chroma > .language-powershell .err {  }
+/* LineTableTD */ .chroma > .language-powershell .lntd { vertical-align: top; padding: 0; margin: 0; border: 0; }
+/* LineTable */ .chroma > .language-powershell .lntable { border-spacing: 0; padding: 0; margin: 0; border: 0; width: 100%; overflow: auto; display: block; }
+/* LineHighlight */ .chroma > .language-powershell .hl { color: #3aa3a8; background-color: #ffffcc; display: block; width: 100% }
+/* LineNumbersTable */ .chroma > .language-powershell .lnt { margin-right: 0.4em; padding: 0 0.4em 0 0.4em; display: block; }
+/* LineNumbers */ .chroma > .language-powershell .ln { margin-right: 0.4em; padding: 0 0.4em 0 0.4em; }
+/* Keyword */ .chroma > .language-powershell .k { color: #00ff14; font-weight: bold }
+/* KeywordConstant */ .chroma > .language-powershell .kc { color: #007020; font-weight: bold }
+/* KeywordDeclaration */ .chroma > .language-powershell .kd { color: #007020; font-weight: bold }
+/* KeywordNamespace */ .chroma > .language-powershell .kn { color: #007020; font-weight: bold }
+/* KeywordPseudo */ .chroma > .language-powershell .kp { color: #007020 }
+/* KeywordReserved */ .chroma > .language-powershell .kr { color: #007020; font-weight: bold }
+/* KeywordType */ .chroma > .language-powershell .kt { color: #902000 }
+/* NameAttribute */ .chroma > .language-powershell .na { color: #4070a0 }
+/* NameBuiltin */ .chroma > .language-powershell .nb { color: #16C60C }
+/* NameClass */ .chroma > .language-powershell .nc { color: #0e84b5; font-weight: bold }
+/* NameConstant */ .chroma > .language-powershell .no { color: #c0c0af }
+/* NameDecorator */ .chroma > .language-powershell .nd { color: #555555; font-weight: bold }
+/* NameEntity */ .chroma > .language-powershell .ni { color: #d55537; font-weight: bold }
+/* NameException */ .chroma > .language-powershell .ne { color: #007020 }
+/* NameFunction */ .chroma > .language-powershell .nf { color: #06287e }
+/* NameLabel */ .chroma > .language-powershell .nl { color: #002070; font-weight: bold }
+/* NameNamespace */ .chroma > .language-powershell .nn { color: #0e84b5; font-weight: bold }
+/* NameTag */ .chroma > .language-powershell .nt { color: #062873; font-weight: bold }
+/* NameVariable */ .chroma > .language-powershell .nv { color: #00ff14 }
+/* LiteralString */ .chroma > .language-powershell .s { color: #4070a0 }
+/* LiteralStringAffix */ .chroma > .language-powershell .sa { color: #4070a0 }
+/* LiteralStringBacktick */ .chroma > .language-powershell .sb { color: #4070a0 }
+/* LiteralStringChar */ .chroma > .language-powershell .sc { color: #4070a0 }
+/* LiteralStringDelimiter */ .chroma > .language-powershell .dl { color: #4070a0 }
+/* LiteralStringDoc */ .chroma > .language-powershell .sd { color: #008000; font-style: italic }
+/* LiteralStringDouble */ .chroma > .language-powershell .s2 { color: #3be0c8 }
+/* LiteralStringEscape */ .chroma > .language-powershell .se { color: #3be0c8; font-weight: bold }
+/* LiteralStringHeredoc */ .chroma > .language-powershell .sh { color: #3be0c8 }
+/* LiteralStringInterpol */ .chroma > .language-powershell .si { color: #70a0d0; font-style: italic }
+/* LiteralStringOther */ .chroma > .language-powershell .sx { color: #c65d09 }
+/* LiteralStringRegex */ .chroma > .language-powershell .sr { color: #235388 }
+/* LiteralStringSingle */ .chroma > .language-powershell .s1 { color: #3be0c8 }
+/* LiteralStringSymbol */ .chroma > .language-powershell .ss { color: #517918 }
+/* LiteralNumber */ .chroma > .language-powershell .m { color: #40a070 }
+/* LiteralNumberBin */ .chroma > .language-powershell .mb { color: #40a070 }
+/* LiteralNumberFloat */ .chroma > .language-powershell .mf { color: #40a070 }
+/* LiteralNumberHex */ .chroma > .language-powershell .mh { color: #40a070 }
+/* LiteralNumberInteger */ .chroma > .language-powershell .mi { color: #40a070 }
+/* LiteralNumberIntegerLong */ .chroma > .language-powershell .il { color: #40a070 }
+/* LiteralNumberOct */ .chroma > .language-powershell .mo { color: #40a070 }
+/* Operator */ .chroma > .language-powershell .o { color: #666666 }
+/* OperatorWord */ .chroma > .language-powershell .ow { color: #007020; font-weight: bold }
+/* Comment */ .chroma > .language-powershell .c { color: #008000; font-style: italic }
+/* CommentHashbang */ .chroma > .language-powershell .ch { color: #008000; font-style: italic }
+/* CommentMultiline */ .chroma > .language-powershell .cm { color: #008000; font-style: italic }
+/* CommentSingle */ .chroma > .language-powershell .c1 { color: #008000; font-style: italic }
+/* CommentSpecial */ .chroma > .language-powershell .cs { color: #60a0b0; background-color: #fff0f0 }
+/* CommentPreproc */ .chroma > .language-powershell .cp { color: #007020 }
+/* CommentPreprocFile */ .chroma > .language-powershell .cpf { color: #007020 }
+/* GenericDeleted */ .chroma > .language-powershell .gd { color: #a00000 }
+/* GenericEmph */ .chroma > .language-powershell .ge { font-style: italic }
+/* GenericError */ .chroma > .language-powershell .gr { color: #ff0000 }
+/* GenericHeading */ .chroma > .language-powershell .gh { color: #000080; font-weight: bold }
+/* GenericInserted */ .chroma > .language-powershell .gi { color: #00a000 }
+/* GenericOutput */ .chroma > .language-powershell .go { color: #888888 }
+/* GenericPrompt */ .chroma > .language-powershell .gp { color: #c65d09; font-weight: bold }
+/* GenericStrong */ .chroma > .language-powershell .gs { font-weight: bold }
+/* GenericSubheading */ .chroma > .language-powershell .gu { color: #800080; font-weight: bold }
+/* GenericTraceback */ .chroma > .language-powershell .gt { color: #0044dd }
+/* TextWhitespace */ .chroma > .language-powershell .w { color: #bbbbbb }

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -1,5 +1,6 @@
 // @import "normalize";
 
 @import "syntax";
+@import "syntax_powershell";
 @import "variables";
 @import "main";


### PR DESCRIPTION
This commit adds specific highlighting for PowerShell code fences, using a slightly modified variant of [this Chroma theme](https://github.com/pauby/chroma-powershellconsole-css).

Closes #21.